### PR TITLE
Remove extra `>` from footer

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="text-center">
     <p>
-    <a href="/overview.html"><span class="fa fa-info-circle"></span> Overview</a>>&ensp;·&ensp;
+    <a href="/overview.html"><span class="fa fa-info-circle"></span> Overview</a>&ensp;·&ensp;
     <a href="/docs/downloads.html"><span class="fa fa-download"></span> Download</a>&ensp;·&ensp;
     <a href="https://github.com/datasketches"><span class="fa fa-github"></span> GitHub</a>&ensp;·&ensp;
     <a href="https://groups.google.com/forum/#!forum/sketches-user"><span class="fa fa-comment"></span> Comments</a>&ensp;·&ensp;


### PR DESCRIPTION
This PR removes the extra `>` from the footer

![screen shot 2018-05-22 at 3 13 03 pm](https://user-images.githubusercontent.com/2983409/40387622-e46b4672-5dd2-11e8-93b7-e38bf6a9de9d.png)
