### PR TITLE
Fix documentation: Set nominal entries by using the builder setter

### DIFF
--- a/docs/Theta/ThetaSketchSetOps.md
+++ b/docs/Theta/ThetaSketchSetOps.md
@@ -26,15 +26,15 @@ The AnotB operation, however, is asymmetric (i.e., sketch order sensitive) and n
 For example:
 
     int k = 4096;
-    UpdateSketch skA = Sketches.updateSketchBuilder().build(k);
-    UpdateSketch skB = Sketches.updateSketchBuilder().build(k);
-    UpdateSketch skC = Sketches.updateSketchBuilder().build(k);
+    UpdateSketch skA = Sketches.updateSketchBuilder().setNominalEntries(k).build();
+    UpdateSketch skB = Sketches.updateSketchBuilder().setNominalEntries(k).build();
+    UpdateSketch skC = Sketches.updateSketchBuilder().setNominalEntries(k).build();
     
     for (int i=1;  i<=10; i++) { skA.update(i); }
     for (int i=1;  i<=20; i++) { skB.update(i); }
     for (int i=6;  i<=15; i++) { skC.update(i); } //overlapping set
     
-    Union union = Sketches.setOperationBuilder().buildUnion(k);
+    Union union = Sketches.setOperationBuilder().setNominalEntries(k).buildUnion();
     union.update(skA);
     union.update(skB);
     // ... continue to iterate on the input sketches to union
@@ -44,7 +44,7 @@ For example:
     
     //Intersection is similar
     
-    Intersection inter = Sketches.setOperationBuilder().buildIntersection(k);
+    Intersection inter = Sketches.setOperationBuilder().setNominalEntries(k).buildIntersection();
     inter.update(unionSk);
     inter.update(skC);
     // ... continue to iterate on the input sketches to intersect
@@ -54,7 +54,7 @@ For example:
     
     //The AnotB operation is a little different as it is stateless and not iterative:
     
-    AnotB aNotB = Sketches.setOperationBuilder().buildANotB(k);
+    AnotB aNotB = Sketches.setOperationBuilder().setNominalEntries(k).buildANotB();
     aNotB.update(skA, skC);
     
     CompactSketch not = aNotB.getResult();


### PR DESCRIPTION
The example code in documention https://datasketches.github.io/docs/Theta/ThetaSketchSetOps.html is incorrect. This PR fixes the example.


Running the current example gives :
```console
scala> Sketches.updateSketchBuilder().build(4096)
<console>:25: error: type mismatch;
 found   : Int(4096)
 required: com.yahoo.memory.WritableMemory
       Sketches.updateSketchBuilder().build(4096)
```
This is because the `build()` method no longer accept nominal entries, we must use `setNominalEntries()` .  See https://github.com/DataSketches/sketches-core/commit/26261d63cabc9645ad5a38532af96f866f8fa6f0#diff-6b8c8509ba97e6f8b9429c7c49cdd161L220


With this fix the output is:
```console
scala> val update_sketch = Sketches.updateSketchBuilder().setNominalEntries(16384).build()
update_sketch: com.yahoo.sketches.theta.UpdateSketch =

### HeapQuickSelectSketch SUMMARY:
   Nominal Entries (k)     : 16384
   Estimate                : 0.0
   Upper Bound, 95% conf   : 0.0
   Lower Bound, 95% conf   : 0.0
   p                       : 1.0
   Theta (double)          : 1.0
   Theta (long)            : 9223372036854775807
   Theta (long) hex        : 7fffffffffffffff
   EstMode?                : false
   Empty?                  : true
   Resize Factor           : 8
   Array Size Entries      : 64
   Retained Entries        : 0
   Update Seed             : 2329 | 9001
   Seed Hash               : 93cc
### END SKETCH SUMMARY
```