### PR TITLE
Add links to presentations shared in user forum

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -10,6 +10,7 @@
     <li><a href="{{site.docs_dir}}/Background/TheChallenge.html">•The Challenge</a></li>
     <li><a href="{{site.docs_dir}}/Background/SketchOrigins.html">•Sketch Origins</a></li>
     <li><a href="{{site.docs_dir}}/Background/SketchElements.html">•Sketch Elements</a></li>
+    <li><a href="{{site.docs_dir}}/Background/Presentations.html">•Presentations</a></li>
     <li><a href="{{site.docs_pdf_dir}}/DataSketches_deck.pdf">•Overview Slide Deck</a></li>
   </div>
 

--- a/docs/Background/Presentations.md
+++ b/docs/Background/Presentations.md
@@ -1,0 +1,38 @@
+---
+layout: doc_page
+---
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+## Presentations
+
+| Title     | HUG Meetup Feb 2017: Data Sketches: A required toolkit for Big Data Analytics |
+| --------- | ----------------------------------------------------------------------------- |
+| Synopsis  | Overview of Datasketches project, together with case studies and examples.    |
+| Presenter | Jon Malkin and Alexander Saydakov                                             |
+| Date      | February 2017                                                                 |
+| Links     | [YouTube](https://www.youtube.com/watch?v=IrRjzzut40g&feature=youtu.be)       |
+
+| Title     | Simons Institute May 2018: Mergeable Summaries and the Data Sketches Library |
+| --------- | ---------------------------------------------------------------------------- |
+| Synopsis  | Suitability of the Data Sketches library to big data processing.             |
+| Presenter | Edo Liberty and Justin Thaler                                                |
+| Date      | February 2017                                                                |
+| Links     | [YouTube](https://www.youtube.com/watch?v=jezpA1kkgUk&feature=youtu.be)      |
+

--- a/src/main/resources/docgen/toc.json
+++ b/src/main/resources/docgen/toc.json
@@ -5,6 +5,7 @@
         {"class":"Doc",  "desc" : "The Challenge",                "dir" : "Background", "file": "TheChallenge" },
         {"class":"Doc",  "desc" : "Sketch Origins",               "dir" : "Background", "file": "SketchOrigins" },
         {"class":"Doc",  "desc" : "Sketch Elements",              "dir" : "Background", "file": "SketchElements" },
+        {"class":"Doc",  "desc" : "Presentations",                "dir" : "Background", "file": "Presentations" },
         {"class":"Doc",  "desc" : "Overview Slide Deck",          "dir" : "", "file": "DataSketches_deck", "pdf":"true" },
       ]
     },
@@ -35,7 +36,7 @@
           [
             {"class":"Doc",  "desc" : "Features Matrix",             "dir" : "", "file": "DistinctCountFeaturesMatrix" },
             {"class":"Doc",  "desc" : "Figures-of-Merit Comparison", "dir" : "", "file": "DistinctCountMeritComparisons"},
-            
+
             { "class":"Dropdown", "desc" : "CPC Sketches", "array":
               [
                 {"class":"Doc",  "desc" : "CPC Sketch",                               "dir" : "CPC", "file": "CPC" },
@@ -50,7 +51,7 @@
                 },
               ]
             },
-    
+
             { "class":"Dropdown", "desc" : "HyperLogLog Sketches", "array":
               [
                 {"class":"Doc",  "desc" : "HLL Sketch",                               "dir" : "HLL", "file": "HLL" },
@@ -73,11 +74,11 @@
                 },
               ]
             },
-    
+
             { "class":"Dropdown", "desc" : "Theta Sketches", "array":
               [
                 { "class":"Doc",  "desc" : "Theta Sketch Framework",            "dir" : "Theta", "file": "ThetaSketchFramework" },
-                
+
                 { "class":"Dropdown", "desc" : "Theta Examples", "array":
                   [
                     {"class":"Doc",  "desc" : "Concurrent Theta Sketch",          "dir" : "Theta", "file": "ConcurrentThetaSketch" },
@@ -88,7 +89,7 @@
                     {"class":"Doc",  "desc" : "Using Sketches in Druid",          "dir" : "",      "file": "DruidIntegration" },
                   ]
                 },
-                
+
                 { "class":"Dropdown", "desc" : "KMV Tutorial", "array":
                   [
                     {"class":"Doc",  "desc" : "The Inverse Estimate",           "dir" : "Theta", "file": "InverseEstimate" },
@@ -99,14 +100,14 @@
                     {"class":"Doc",  "desc" : "Update V(kth) Rule",             "dir" : "Theta", "file": "KMVupdateVkth" },
                   ]
                 },
-    
+
                 { "class":"Dropdown", "desc" : "Set Operations and P-sampling", "array":
                   [
                     {"class":"Doc",  "desc" : "Set Operations",                 "dir" : "Theta", "file": "ThetaSketchSetOps" },
                     {"class":"Doc",  "desc" : "<i>p</i>-Sampling",              "dir" : "Theta",  "file": "ThetaPSampling" },
                   ]
                 },
-    
+
                 { "class":"Dropdown", "desc" : "Accuracy", "array":
                   [
                     {"class":"Doc",  "desc" : "Basic Accuracy",                 "dir" : "Theta", "file": "ThetaAccuracy" },
@@ -116,20 +117,20 @@
                     {"class":"Doc",  "desc" : "Unions With Different k",        "dir" : "Theta", "file": "AccuracyOfDifferentKUnions" },
                   ]
                 },
-    
+
                 { "class":"Dropdown", "desc" : "Size", "array":
                   [
                     {"class":"Doc",  "desc" : "Theta Sketch Size",                 "dir" : "Theta", "file": "ThetaSize" },
                   ]
                 },
-    
+
                 { "class":"Dropdown", "desc" : "Speed", "array":
                   [
                     {"class":"Doc",  "desc" : "Update Speed",                      "dir" : "Theta", "file": "ThetaUpdateSpeed" },
                     {"class":"Doc",  "desc" : "Merge Speed",                       "dir" : "Theta", "file": "ThetaMergeSpeed" },
                   ]
                 },
-    
+
                 { "class":"Dropdown", "desc" : "Theta Sketch Theory", "array":
                   [
                     {"class":"Doc",  "desc" : "Theta Sketch Framework (PDF)",      "dir" : "",      "file": "ThetaSketchFramework", "pdf":"true" },
@@ -142,7 +143,7 @@
                 },
               ]
             },
-    
+
             { "class":"Dropdown", "desc" : "Tuple Sketches", "array":
               [
                 {"class":"Doc",  "desc" : "Tuple Overview",           "dir" : "Tuple", "file": "TupleOverview" },
@@ -164,14 +165,14 @@
         { "class":"Dropdown", "desc" : "Most Frequent", "array":
           [
             {"class":"Doc",  "desc" : "Frequency Sketches Overview",  "dir" : "Frequency", "file": "FrequencySketchesOverview" },
-    
+
             { "class":"Dropdown", "desc" : "Frequent Item Sketches", "array":
               [
                 {"class":"Doc",  "desc" : "Frequent Items Overview",      "dir" : "Frequency", "file": "FrequentItemsOverview" },
                 {"class":"Doc",  "desc" : "Frequent Items Error Table",   "dir" : "Frequency", "file": "FrequentItemsErrorTable" },
                 {"class":"Doc",  "desc" : "Frequent Items References",    "dir" : "Frequency", "file": "FrequentItemsReferences" },
                 {"class":"Doc",  "desc" : "Frequent Items Performance",   "dir" : "Frequency", "file": "FrequentItemsPerformance" },
-    
+
                 { "class":"Dropdown", "desc" : "Most Frequent Examples", "array":
                   [
                     {"class":"Doc",  "desc" : "Frequent Items Java Example",  "dir" : "Frequency", "file": "FrequentItemsJavaExample" },
@@ -183,7 +184,7 @@
                 },
               ]
             },
-    
+
             { "class":"Dropdown", "desc" : "Frequent Distinct Sketches", "array":
               [
                 {"class":"Doc",  "desc" : "Frequent Distinct Tuples Sketch", "dir" : "Frequency", "file": "FrequentDistinctTuplesSketch" },
@@ -196,7 +197,7 @@
           [
             {"class":"Doc",  "desc" : "Quantiles Overview",                       "dir" : "Quantiles", "file": "QuantilesOverview" },
             {"class":"Doc",  "desc" : "Quantiles Accuracy and Size",              "dir" : "Quantiles", "file": "QuantilesAccuracy" },
-    
+
             { "class":"Dropdown", "desc" : "Quantiles Examples", "array":
               [
                 {"class":"Doc",  "desc" : "Quantiles Sketch Java Example",            "dir" : "Quantiles", "file": "QuantilesJavaExample" },
@@ -231,7 +232,7 @@
             {"class":"Doc",  "desc" : "Reservoir Sampling",               "dir" : "Sampling", "file": "ReservoirSampling" },
             {"class":"Doc",  "desc" : "Reservoir Sampling Performance",   "dir" : "Sampling", "file": "ReservoirSamplingPerformance" },
             {"class":"Doc",  "desc" : "VarOpt Sampling",                  "dir" : "Sampling", "file": "VarOptSampling" },
-    
+
             { "class":"Dropdown", "desc" : "Sampling Examples", "array":
               [
                 {"class":"Doc",  "desc" : "Reservoir Sampling Java Example",  "dir" : "Sampling", "file": "ReservoirSamplingJava" },
@@ -242,7 +243,7 @@
             },
           ]
         },
-      ] 
+      ]
     },
 
     { "class":"Dropdown", "desc" : "Community", "array":


### PR DESCRIPTION
This will hopefully be one of many contributions that I can make regarding additional notes and documentation.

Yesterday some links were shared by Alexander Saydakov on the user forum which would also be useful on the website.

I have run the TOC generator, but have not seen any further html page generated from the markdown.  Please let me know if there are further steps that I need to run!