### PR TITLE
Fix expanding TOC menus for navigation items

### DIFF
--- a/_includes/tocScript.html
+++ b/_includes/tocScript.html
@@ -3,8 +3,12 @@
   (function () {
 
     var findLineItem = function (path) {
-      return document.querySelector(`[href="${path}"]`);
+      return document.querySelector(`#toc [href="${path}"]`);
     };
+
+    function findNavItem(path) {
+      return document.querySelector(`.nav [href="${path}"]`);
+    }
 
     var highlighLineItem = function (element) {
       element.classList.add('highlight');
@@ -36,9 +40,13 @@
     };
 
     var highlightAndOpenMenu = function () {
+      // Highlight & expand nav item in the TOC
       var currentLineItem = findLineItem(document.location.pathname);
       highlighLineItem(currentLineItem);
       openAllFromList(findAllCollapseParents(currentLineItem));
+
+      // Highlight nav item in top navigation
+      highlighLineItem(findNavItem(document.location.pathname));
     };
 
     $(highlightAndOpenMenu);


### PR DESCRIPTION
https://github.com/apache/incubator-datasketches-website/issues/91
@leerho This fixes the first issue we discussed, by doing 2 things:
- Instead of searching for the first link on the page with a `href` same as the current URL, we search only inside the `#toc`.
- To maintain previous functionality, we're also checking if the top navigation includes a link to the current page, and highlight that link if so.

With this fix in place, there's no need to use any special syntax for the top navigation links or the TOC links, everything will work as expected.