### PR TITLE
fixes-grammatical-error

### DIFF
--- a/docs/Community/index.md
+++ b/docs/Community/index.md
@@ -51,7 +51,7 @@ Chat with users and developers on Slack in _the-asf.slack.com_ workspace.
 * Otherwise, please send an email to our developers mail list above and we will send you an invite to join our slack channel. Join the _#datasketches_ channel when you receive notification.
 
 ### Bugs and Issues
-If you have a problem or issue with the any aspect of the performance, accuracy or documentation in our library please file an issue with the relevant [Component](https://datasketches.apache.org/docs/Architecture/Components.html) GitHub site.
+If you have a problem or issue with any aspect of the performance, accuracy or documentation in our library please file an issue with the relevant [Component](https://datasketches.apache.org/docs/Architecture/Components.html) GitHub site.
 
 
 ## Contributing


### PR DESCRIPTION
Fixes a grammatical error in index.md file under Bugs and Issues in Community folder(docs).