### PR TITLE
Fix example: update() => union()

### DIFF
--- a/docs/Tuple/TupleJavaExample.md
+++ b/docs/Tuple/TupleJavaExample.md
@@ -73,8 +73,8 @@ layout: doc_page
       ArrayOfDoublesSketch sketch2 = ArrayOfDoublesSketches.wrapSketch(Memory.wrap(bytes2));
 
       ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-      union.update(sketch1);
-      union.update(sketch2);
+      union.union(sketch1);
+      union.union(sketch2);
       ArrayOfDoublesSketch unionResult = union.getResult();
 
       System.out.println("Union unique count estimate: " + unionResult.getEstimate());


### PR DESCRIPTION
update() was deprecated and replaced by union(), and as of 3.0 has been removed.

https://github.com/apache/datasketches-java/pull/367/files

There are probably more examples that should be fixed, I just noticed this one was incorrect.