### PR TITLE
Fixed ThetaSketchJava example; incorrect method call.

### DIFF
--- a/docs/Theta/ThetaJavaExample.md
+++ b/docs/Theta/ThetaJavaExample.md
@@ -68,8 +68,8 @@ layout: doc_page
       Sketch sketch2 = Sketches.wrapSketch(Memory.wrap(bytes2));
 
       Union union = SetOperation.builder().buildUnion();
-      union.update(sketch1);
-      union.update(sketch2);
+      union.union(sketch1);
+      union.union(sketch2);
       Sketch unionResult = union.getResult();
 
       // debug summary of the union result sketch
@@ -80,8 +80,8 @@ layout: doc_page
       System.out.println("Union unique count upper bound 95% confidence: " + unionResult.getUpperBound(2));
 
       Intersection intersection = SetOperation.builder().buildIntersection();
-      intersection.update(sketch1);
-      intersection.update(sketch2);
+      intersection.intersection(sketch1);
+      intersection.intersection(sketch2);
       Sketch intersectionResult = intersection.getResult();
 
       // debug summary of the intersection result sketch


### PR DESCRIPTION
Hello,
I was trying the DataSketches library, starting with the ThetaSketches example for Java core.
I believe there are some typos in the example.
The example called `update(<sketch>)` method for updating the union and intersection sketches.
This is not supported by the class. Fixed/replaced with `union` and `intersection` respectively.

This is an excellent library btw! An amazing effort! Thanks to all the devs involved!