### PR TITLE
Remove outdated study

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -248,7 +248,6 @@
         <a data-toggle="collapse" class="menu collapsed" href="#collapse_quantiles_studies">Quantiles Studies</a>
       </p>
       <div class="collapse" id="collapse_quantiles_studies">
-        <li><a href="{{site.docs_dir}}/QuantilesStudies/KllSketchVsTDigest.html">•KLL sketch vs t-digest</a></li>
         <li><a href="{{site.docs_dir}}/QuantilesStudies/DruidApproxHistogramStudy.html">•Druid Approximate Histogram</a></li>
         <li><a href="{{site.docs_dir}}/QuantilesStudies/MomentsSketchStudy.html">•Moments Sketch Study</a></li>
         <li><a href="{{site.docs_dir}}/QuantilesStudies/QuantilesStreamAStudy.html">•Quantiles StreamA Study</a></li>


### PR DESCRIPTION
This study is not relevant anymore. t-Digest code improved since then, and comparing with KLL was not the best idea. Now we have REQ sketch, which seems to be a better candidate for comparison.