### PR TITLE
copyright  from 2024 to 2025

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="text-center">
       <p>
-        <div>Copyright © 2024 <a href="https://www.apache.org">Apache Software Foundation</a>, 
+        <div>Copyright © 2025 <a href="https://www.apache.org">Apache Software Foundation</a>, 
           Licensed under the Apache License, Version 2.0. All Rights Reserved.
           | <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a><br>
           Apache DataSketches, Apache, the Apache feather logo, and the Apache DataSketches project logos are trademarks of The Apache Software Foundation.<br>


### PR DESCRIPTION
copyright 2024 to 2025 in footer
https://datasketches.apache.org/
![Monosnap DataSketches  2025-01-22 11-57-02](https://github.com/user-attachments/assets/6db135f6-6694-4fb2-8563-103f98e5eaf9)
